### PR TITLE
Reused parameter support

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1
@@ -65,7 +65,7 @@ jobs:
           & "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/Common7/IDE/Extensions/TestPlatform/vstest.console.exe" ./tests/QueryableValues.EF6.SqlServer.Tests.EF*/bin/Release/**/BlazarTech.QueryableValues.EF6.SqlServer.Tests.EF*.dll
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: nupkg
           path: ./src/QueryableValues.EF6.SqlServer/bin/Release/*.nupkg
@@ -75,7 +75,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: nupkg
       - name: Push to GitHub Feed
@@ -88,7 +88,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: nupkg
       - name: Push to GitHub Feed

--- a/Version.xml
+++ b/Version.xml
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<VersionPrefix>1.1.0</VersionPrefix>
+		<VersionPrefix>1.1.1</VersionPrefix>
 	</PropertyGroup>
 </Project>

--- a/src/QueryableValues.EF6.SqlServer/QueryableValuesCommandInterceptor.cs
+++ b/src/QueryableValues.EF6.SqlServer/QueryableValuesCommandInterceptor.cs
@@ -127,11 +127,15 @@ namespace BlazarTech.QueryableValues
                                 SerializationFormatIdentifier.Json => SerializationFormat.Json,
                                 _ => throw new NotImplementedException(),
                             };
-                            
+
+#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+                            parameters.TryAdd(valueParameterName, serializationFormat);
+#else
                             if (!parameters.ContainsKey(valueParameterName))
                             {
                                 parameters.Add(valueParameterName, serializationFormat);
                             }
+#endif
 
 #if NET452 || NET472
                             sb.Append(originalCommandText.Substring(lastStartIndex, match2.Index - lastStartIndex));

--- a/src/QueryableValues.EF6.SqlServer/QueryableValuesCommandInterceptor.cs
+++ b/src/QueryableValues.EF6.SqlServer/QueryableValuesCommandInterceptor.cs
@@ -128,13 +128,13 @@ namespace BlazarTech.QueryableValues
                                 _ => throw new NotImplementedException(),
                             };
 
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
-                            parameters.TryAdd(valueParameterName, serializationFormat);
-#else
+#if NET452 || NET472
                             if (!parameters.ContainsKey(valueParameterName))
                             {
                                 parameters.Add(valueParameterName, serializationFormat);
-                            }
+                            }                            
+#else
+                            parameters.TryAdd(valueParameterName, serializationFormat);
 #endif
 
 #if NET452 || NET472

--- a/src/QueryableValues.EF6.SqlServer/QueryableValuesCommandInterceptor.cs
+++ b/src/QueryableValues.EF6.SqlServer/QueryableValuesCommandInterceptor.cs
@@ -127,8 +127,11 @@ namespace BlazarTech.QueryableValues
                                 SerializationFormatIdentifier.Json => SerializationFormat.Json,
                                 _ => throw new NotImplementedException(),
                             };
-
-                            parameters.Add(valueParameterName, serializationFormat);
+                            
+                            if (!parameters.ContainsKey(valueParameterName))
+                            {
+                                parameters.Add(valueParameterName, serializationFormat);
+                            }
 
 #if NET452 || NET472
                             sb.Append(originalCommandText.Substring(lastStartIndex, match2.Index - lastStartIndex));


### PR DESCRIPTION
Fixes and add a test for a case where EF6 can reuse internal parameters across the generated query.

Credit @michlns